### PR TITLE
Trigger jobs based on stage and production addons new release

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -311,9 +311,9 @@ def get_api(url, token):
 
 def process_hook(api, data, slack_webhook_url, repository_data):
     def _trigger_jobs(
-        _addon, _slack_webhook_url, _slack_errors_webhook_url, _repository_data
+        _addon, _ocm_env, _slack_webhook_url, _slack_errors_webhook_url, _repository_data
     ):
-        _jobs = _repository_data["products_jobs_mapping"].get(_addon)
+        _jobs = _repository_data["products_jobs_mapping"][_addon][_ocm_env]
         if not _jobs:
             app.logger.info(f"{project.name}: No job found for product: {_addon}")
             return
@@ -341,12 +341,13 @@ def process_hook(api, data, slack_webhook_url, repository_data):
             changed_file = change.get("new_path")
             # TODO: Get product version from changed_file and send it to slack
             matches = re.match(
-                r"addons/(?P<product>.*)/addonimagesets/(production|stage)/.*.yaml",
+                r"addons/(?P<product>.*)/addonimagesets/(?P<env>production|stage)/.*.yaml",
                 changed_file,
             )
             if matches:
                 _trigger_jobs(
                     _addon=matches.group("product"),
+                    _ocm_env=matches.group("env"),
                     _slack_webhook_url=slack_webhook_url,
                     _slack_errors_webhook_url=slack_errors_webhook_url,
                     _repository_data=repository_data,

--- a/app/app.py
+++ b/app/app.py
@@ -311,7 +311,11 @@ def get_api(url, token):
 
 def process_hook(api, data, slack_webhook_url, repository_data):
     def _trigger_jobs(
-        _addon, _ocm_env, _slack_webhook_url, _slack_errors_webhook_url, _repository_data
+        _addon,
+        _ocm_env,
+        _slack_webhook_url,
+        _slack_errors_webhook_url,
+        _repository_data,
     ):
         _jobs = _repository_data["products_jobs_mapping"][_addon][_ocm_env]
         if not _jobs:

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -14,8 +14,12 @@ repositories:
     slack-webhook-url: <slack webhook url to post job status>
     products_jobs_mapping:
       dbaas-operator:
-        - <openshift-ci job1 name>
-        - <openshift-ci job2 name>
+        stage:
+          - <openshift-ci job1 name>
+          - <openshift-ci job2 name>
+        production:
+          - <openshift-ci job3 name>
+          - <openshift-ci job4 name>
 
 # For operators
 openshift_ci_jobs:


### PR DESCRIPTION
Changes to trigger jobs based on new merge of addons in stage and production. 
Update configmap like this:
```
products_jobs_mapping:
        rhods:
            stage:
              - periodic-ci-CSPI-QE-MSI-rhods-addon-interop-v4.13-GA-stage-smoke-rosa-rhods-addon-baseline-fips
              - periodic-ci-CSPI-QE-MSI-rhods-addon-interop-v4.13-GA-stage-smoke-osd-rhods-addon-baseline-fips
            production:
              - periodic-ci-CSPI-QE-MSI-rhods-addon-interop-v4.13-GA-production-smoke-rosa-rhods-addon-baseline-fips
              - periodic-ci-CSPI-QE-MSI-rhods-addon-interop-v4.13-GA-production-smoke-osd-rhods-addon-baseline-fips            
```            